### PR TITLE
Properly detect and include named errors (i.e. `error[E…]: …`) in stderr snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Fixed
 
-- n/a
+- Named errors (i.e. `error[E…]: …`) are now properly detected and included in error snapshots
 
 ### Performance
 


### PR DESCRIPTION
### Full log:

```
    Checking …
error[E0433]: failed to resolve: use of undeclared crate or module `pwyxfa`
--> /tests/expand/fail/test.rs:1:1
|
1 | pwyxfa::skpwbd! {
| ^^^^^^ use of undeclared crate or module `pwyxfa`
For more information about this error, try `rustc --explain E0433`.
error: could not compile `<CRATE>` (bin "<BIN>") due to previous error
...
```

### Normalized log:

#### Before:

```
error: could not compile `<CRATE>` (bin "<BIN>") due to previous error
...
```

#### After:
```
error[E0433]: failed to resolve: use of undeclared crate or module `pwyxfa`
--> /tests/expand/fail/test.rs:1:1
|
1 | pwyxfa::skpwbd! {
| ^^^^^^ use of undeclared crate or module `pwyxfa`
For more information about this error, try `rustc --explain E0433`.
error: could not compile `<CRATE>` (bin "<BIN>") due to previous error
...
```