### PR TITLE
Restrict logging of snapshot blocks to 100 lines per block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Changed
 
-- n/a
+- Restricted logging of snapshot blocks to 100 lines per block.
 
 ### Deprecated
 


### PR DESCRIPTION
Omitted lines are marked like this:

```
Cras justo odio, dapibus ac facilisis in, egestas eget quam. Duis mollis, est non commodo luctus,
nisi erat porttitor ligula, eget lacinia odio sem nec elit. Maecenas faucibus mollis interdum.
Maecenas sed diam eget risus varius blandit sit amet non magna. Curabitur blandit tempus porttitor.
Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cras justo odio, dapibus ac facilisis in, egestas eget quam.

... 42 LINES TRUNCATED IN LOG ...

Donec id elit non mi porta gravida at eget metus. Nulla vitae elit libero, a pharetra augue.
Vestibulum id ligula porta felis euismod semper. Nulla vitae elit libero, a pharetra augue.
Curabitur blandit tempus porttitor. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.
```